### PR TITLE
Fix critical async/await bug in federation handler

### DIFF
--- a/backend/src/handlers/federation.ts
+++ b/backend/src/handlers/federation.ts
@@ -40,7 +40,7 @@ export class FederationHandlers {
       console.log(`🔑 Key pairs retrieved for: ${identifier}`);
       
       // Create and return the Person object
-      const person = ActorModel.createPersonObject(ctx, identifier, actorData, keyPairs);
+      const person = await ActorModel.createPersonObject(ctx, identifier, actorData, keyPairs);
       console.log(`👤 Person object created for: ${identifier}`);
       
       return person;


### PR DESCRIPTION
- Add missing await keyword for ActorModel.createPersonObject call
- This was causing Person objects to return as Promise objects instead of proper ActivityPub Person objects
- Should resolve 500 errors when requesting actor endpoints